### PR TITLE
Memory Leak Code Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arduino Median Filter Library 2
 The median filter library implements a moving median filter. The library stores the last N elements of the window and calculates the median. The class uses templates to allow working with different types (int, long, float, ...). <br />
 More information https://www.luisllamas.es/libreria-arduino-median-filter/ <br>
-English translation: https://www-luisllamas-es.translate.goog/libreria-arduino-median-filter/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en-US&_x_tr_pto=wapp 
+[English translation](https://www-luisllamas-es.translate.goog/libreria-arduino-median-filter/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en-US&_x_tr_pto=wapp)
 
 ## Instructions for use
 The median filter class follows the algorithm proposed by Phil Ekstrom for the quick calculation of the median filter. It uses a circular buffer to store the values by age together with a linkedlist to maintain the order of the elements. <br />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Arduino Median Filter Library 2
 The median filter library implements a moving median filter. The library stores the last N elements of the window and calculates the median. The class uses templates to allow working with different types (int, long, float, ...). <br />
-More information https://www.luisllamas.es/libreria-arduino-median-filter/
+More information https://www.luisllamas.es/libreria-arduino-median-filter/ <br>
+English translation: https://www-luisllamas-es.translate.goog/libreria-arduino-median-filter/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en-US&_x_tr_pto=wapp 
 
 ## Instructions for use
 The median filter class follows the algorithm proposed by Phil Ekstrom for the quick calculation of the median filter. It uses a circular buffer to store the values by age together with a linkedlist to maintain the order of the elements. <br />

--- a/src/MedianFilterLib2.h
+++ b/src/MedianFilterLib2.h
@@ -24,17 +24,18 @@ typedef T (MedianFilter2::*Action)(T);
 
 public:
 	MedianFilter2<T>(const size_t windowSize);
+
 	T AddValue(T item);
 	T GetFiltered() const;
 
 private:
 	struct node
 	{
-		struct node *next;      // Apunta al siguiente elemento en orden
+		struct node *next;      // Point to the next element in order (Apunta al siguiente elemento en orden)
 		T value;
 	};
 
-	Action addValue;			// Puntero para permitir cambiar entra algoritmo 3 o N
+	Action addValue;			// Pointer to allow switching between algorithm 3 or N (Puntero para permitir cambiar entra algoritmo 3 o N)
 	T addValue3(T item);
 	T addValueN(T item);
 	T median3(T a, T b, T c);
@@ -43,7 +44,7 @@ private:
 	T _lastFiltered;
 
 	const static int _stopper = 0;
-	struct node *_buffer;		// Buffer para los elementos por orden de llegada
+	struct node *_buffer;		// Buffer for items in order of arrival (Buffer para los elementos por orden de llegada)
 	struct node *_iterator; 
 
 	struct node _smaller;
@@ -107,7 +108,7 @@ T MedianFilter2<T>::addValueN(T value)
 
 	for (int iCount = 0; iCount < _windowSize; ++iCount)
 	{
-		// Gestion de elementos impares
+		// Management of odd elements (Gestion de elementos impares)
 		if (_accessor->next == _iterator)
 			_accessor->next = _successor;
 
@@ -125,7 +126,7 @@ T MedianFilter2<T>::addValueN(T value)
 		_accessorPrev = _accessor;  
 		_accessor = _accessor->next;
 
-		// Gestion de elementos pares
+		// Management of even elements (Gestion de elementos pares)
 		if (_accessor->next == _iterator)
 			_accessor->next = _successor;
 

--- a/src/MedianFilterLib2.h
+++ b/src/MedianFilterLib2.h
@@ -25,6 +25,9 @@ typedef T (MedianFilter2::*Action)(T);
 public:
 	MedianFilter2<T>(const size_t windowSize);
 
+	~MedianFilter2<T>(); // prototype the destructor
+
+
 	T AddValue(T item);
 	T GetFiltered() const;
 
@@ -66,6 +69,12 @@ MedianFilter2<T>::MedianFilter2(const size_t windowSize)
 		addValue = &MedianFilter2::addValue3;
 	else
 		addValue = &MedianFilter2::addValueN;
+}
+
+// implement the desructor
+template<typename T>
+MedianFilter2<T>::~MedianFilter2() {
+	delete [] _buffer;
 }
 
 template<typename T>


### PR DESCRIPTION
I discovered a memory leak in the MedianFilterLib code while using it on my project and I wish to offer a fix to the library code.  

In brief, my project uses a  ESP8266 combined with an external ADC to read four sensors where I use the Median Filter Library to smooth out any spurious data spikes by reading in a window of 11 consecutive sensor values and then using the library to return a median value.  While running a test case where I continuously looped sensor readings, I discovered that the microcontroller would reset and throw an exception / stack dump every 20 seconds or so.  Decoding the exception / stack trace led me to discover a memory leak in the MedianFilter library code.

The root cause of the memory leak is Line 58: 
 `	_buffer = new node[windowSize];` 
where the `new` operator dynamically allocates heap memory for the `_buffer` array but then the library fails to explicitly de-allocate the buffer array to free the memory.  The fix is to implement an explicit destructor that de-allocates the memory assigned to `_buffer`.

I've tested this code fix in my project and the memory is now rock solid and the microcontroller no longer resets.

I've also made a few other minor changes 

1. added an English translation to the Spanish comments by the original library author.
2. added an additional "More Information" link in the README.md file to an English translation of the website.

Acknowledgement to my brother-in-law, Steve Polus, who helped me code the destructor.


